### PR TITLE
Fix/revert Root Navigation structure; refactor @Dependency inits

### DIFF
--- a/CustomContacts/Code/UI/Main/Contacts/ContactListView.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactListView.swift
@@ -13,31 +13,29 @@ struct ContactListView: View {
 	let onToggleTapped: () -> Void
 
 	var body: some View {
-		NavigationStack {
-			VStack {
-				FilterView(
-					filterQueries: viewModel.filterQueries,
-					onAddQueryTapped: { viewModel.addQuery($0) },
-					onRemoveQueryTapped: { viewModel.removeQuery($0) },
-					onClearTapped: { viewModel.removeAllQueries() }
-				)
+		VStack {
+			FilterView(
+				filterQueries: viewModel.filterQueries,
+				onAddQueryTapped: { viewModel.addQuery($0) },
+				onRemoveQueryTapped: { viewModel.removeQuery($0) },
+				onClearTapped: { viewModel.removeAllQueries() }
+			)
 
-				List {
-					ForEach(viewModel.contactsDisplayable()) { contact in
-						NavigationLink(
-							destination: {
-								ContactDetailView(contact: contact)
-							},
-							label: {
-								ContactCardView(contact: contact)
-							}
-						)
-					}
+			List {
+				ForEach(viewModel.contactsDisplayable()) { contact in
+					NavigationLink(
+						destination: {
+							ContactDetailView(contact: contact)
+						},
+						label: {
+							ContactCardView(contact: contact)
+						}
+					)
 				}
-				.searchable(text: $viewModel.searchText)
-				.refreshable {
-					await viewModel.loadContacts(refresh: true)
-				}
+			}
+			.searchable(text: $viewModel.searchText)
+			.refreshable {
+				await viewModel.loadContacts(refresh: true)
 			}
 			.navigationTitle(Localizable.Root.Contacts.title)
 			.toolbar {

--- a/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
@@ -11,7 +11,6 @@ import Dependencies
 import SwiftUI
 
 struct ContactSelectorView: View {
-	@Dependency(\.uuid) private var uuid
 	@StateObject private var viewModel = ViewModel()
 	@Environment(\.dismiss) private var dismiss
 
@@ -57,12 +56,13 @@ struct ContactSelectorView: View {
 
 extension ContactSelectorView: Identifiable {
 	var id: String {
-		uuid().uuidString
+		viewModel.id
 	}
 }
 
 extension ContactSelectorView {
 	private final class ViewModel: ObservableObject {
+		let id: String
 		@Dependency(\.contactsRepository) private var contactsRepository
 
 		@Published private var contacts: [Contact] = []
@@ -80,6 +80,9 @@ extension ContactSelectorView {
 		}
 
 		init() {
+			@Dependency(\.uuid) var uuid
+			self.id = uuid().uuidString
+
 			Task {
 				// Contacts should already have loaded on earlier screen
 				await loadContacts()

--- a/CustomContacts/Code/UI/Main/Filter/FilterQuery.swift
+++ b/CustomContacts/Code/UI/Main/Filter/FilterQuery.swift
@@ -10,24 +10,22 @@ import Combine
 import CustomContactsAPIKit
 import Dependencies
 
-final class FilterQuery: ObservableObject {
-	@Dependency(\.uuid) private var uuid
-	@Dependency(\.contactsRepository) private var contactsRepository
+final class FilterQuery: ObservableObject, Identifiable {
+	let id: String
 
-	@Published var group = ContactGroup.empty
+	@Published var group: ContactGroup
 	@Published var filter = Filter.include
 	@Published var `operator` = Operator.or
 
 	init(isFirstQuery: Bool) {
 		// First query should be `or` so base group is more inclusive of future clauses
 		self.operator = isFirstQuery ? .or : .and
-		group = contactsRepository.allContactsGroup
-	}
-}
 
-extension FilterQuery: Identifiable {
-	var id: String {
-		uuid().uuidString
+		@Dependency(\.uuid) var uuid
+		self.id = uuid().uuidString
+
+		@Dependency(\.contactsRepository) var contactsRepository
+		group = contactsRepository.allContactsGroup
 	}
 }
 

--- a/CustomContacts/Code/UI/Main/Groups/GroupListView.swift
+++ b/CustomContacts/Code/UI/Main/Groups/GroupListView.swift
@@ -36,7 +36,6 @@ struct GroupListView: View {
 			.navigationTitle(Localizable.Root.Groups.title)
 			.sheet(item: $createGroupView) { $0 }
 			.navigationDestination(to: $groupDetailView) { $0 }
-			.modelContainer(for: ContactGroup.self)
 			.toolbar {
 				ToolbarItem(placement: .topBarLeading) {
 					Button("🔄") {
@@ -45,6 +44,7 @@ struct GroupListView: View {
 				}
 			}
 		}
+		.modelContainer(for: ContactGroup.self)
 	}
 
 	private var createGroupButton: some View {
@@ -60,6 +60,6 @@ struct GroupListView: View {
 			}
 		)
 		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-		.padding(Constants.UI.Padding.default)
+		.padding(Constants.UI.Padding.default * 2)
 	}
 }

--- a/CustomContacts/Code/UI/Main/RootView.swift
+++ b/CustomContacts/Code/UI/Main/RootView.swift
@@ -18,25 +18,36 @@ struct RootView: View {
 	private let contactListViewModel = ContactListView.ViewModel()
 
 	var body: some View {
-		contentView
-			.ignoresSafeArea()
+		NavigationStack {
+			contentView
+		}
 	}
 
-	@ViewBuilder
 	private var contentView: some View {
+		/// Ideally `contentView` would be a `Group { ... }` containing a switch statement,
+		/// and each View maintain its own `NavigationStack`.
+		/// However there is a bug when rotating/flipping the `GroupList` which causes the tappable button area to be mirrored.
+		/// In the future animation and structure could be improved once this bug is addressed.
 		ZStack {
-			ContactListView(
-				viewModel: contactListViewModel,
-				onToggleTapped: { showContactList.toggle() }
-			)
-			.opacity(showContactList ? 1 : 0)
-
-			GroupListView(onToggleTapped: { showContactList.toggle() })
-				// Handles mirror image
-				.rotation3DEffect(.degrees(-180), axis: Layout.rotationAxis)
-				.opacity(showContactList ? 0 : 1)
+			if showContactList {
+				ContactListView(
+					viewModel: contactListViewModel,
+					onToggleTapped: { showContactList.toggle() }
+				)
+			} else {
+				GroupListView(onToggleTapped: { showContactList.toggle() })
+					// Handles mirror image
+					.rotation3DEffect(-Layout.rotationAngle, axis: Layout.rotationAxis)
+			}
 		}
 		.rotation3DEffect(showContactList ? .zero : Layout.rotationAngle, axis: Layout.rotationAxis)
 		.animation(.easeInOut, value: showContactList)
 	}
 }
+
+/*
+
+Rotate on swipe-from-left-edge in continuous rotation
+ UIScreenEdgePanGestureRecognizer
+
+*/


### PR DESCRIPTION
Ideally `contentView` would be a `Group { ... }` containing a switch statement, and each View maintain its own `NavigationStack`. However there is a bug when rotating/flipping the `GroupList` which causes the tappable button area to be mirrored.

In the future animation and structure could be improved once this bug is addressed.