### PR TITLE
Add swipe gesture to remove filter

### DIFF
--- a/CustomContacts.xcodeproj/project.pbxproj
+++ b/CustomContacts.xcodeproj/project.pbxproj
@@ -57,10 +57,12 @@
 		E88DA2A02AA12188002797AB /* FilterQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DA29F2AA12188002797AB /* FilterQuery.swift */; };
 		E8C33FF32A9F982A0004E455 /* ContactCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF22A9F982A0004E455 /* ContactCardView.swift */; };
 		E8C33FF52A9FE04E0004E455 /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF42A9FE04E0004E455 /* FilterView.swift */; };
+		E8C33FF82AA0E4C50004E455 /* SwipeableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF72AA0E4C50004E455 /* SwipeableRowView.swift */; };
 		E8D67B992A8AB1B800300FE0 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B982A8AB1B800300FE0 /* RootView.swift */; };
 		E8D67B9B2A8AB21C00300FE0 /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B9A2A8AB21C00300FE0 /* ContactListView.swift */; };
 		E8D67B9D2A8AB27200300FE0 /* GroupListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B9C2A8AB27200300FE0 /* GroupListView.swift */; };
 		E8D67B9F2A8AB82A00300FE0 /* GroupCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B9E2A8AB82A00300FE0 /* GroupCreationView.swift */; };
+		E8FA23DC2AA77847006DE429 /* PreferenceKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8FA23DB2AA77847006DE429 /* PreferenceKeys.swift */; };
 		F40191112301E7FB00CF1502 /* DecodingError+DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40191102301E7FB00CF1502 /* DecodingError+DisplayableError.swift */; };
 		F4CD7028200003E10013EE7B /* ApplicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CD701B200003E10013EE7B /* ApplicationService.swift */; };
 		F4CD706420002E7C0013EE7B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4CD706220002E7C0013EE7B /* LaunchScreen.storyboard */; };
@@ -149,10 +151,12 @@
 		E88DA29F2AA12188002797AB /* FilterQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterQuery.swift; sourceTree = "<group>"; };
 		E8C33FF22A9F982A0004E455 /* ContactCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCardView.swift; sourceTree = "<group>"; };
 		E8C33FF42A9FE04E0004E455 /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
+		E8C33FF72AA0E4C50004E455 /* SwipeableRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableRowView.swift; sourceTree = "<group>"; };
 		E8D67B982A8AB1B800300FE0 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		E8D67B9A2A8AB21C00300FE0 /* ContactListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		E8D67B9C2A8AB27200300FE0 /* GroupListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupListView.swift; sourceTree = "<group>"; };
 		E8D67B9E2A8AB82A00300FE0 /* GroupCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCreationView.swift; sourceTree = "<group>"; };
+		E8FA23DB2AA77847006DE429 /* PreferenceKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceKeys.swift; sourceTree = "<group>"; };
 		F40191102301E7FB00CF1502 /* DecodingError+DisplayableError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DecodingError+DisplayableError.swift"; sourceTree = "<group>"; };
 		F4AB7AB52534CC6F008372B6 /* CustomContactsAPIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CustomContactsAPIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4AB7AB62534CC6F008372B6 /* CustomContactsHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CustomContactsHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -399,6 +403,8 @@
 			isa = PBXGroup;
 			children = (
 				E87A3DF72A8BE4A30068F34C /* NavigationLinkHelper.swift */,
+				E8C33FF72AA0E4C50004E455 /* SwipeableRowView.swift */,
+				E8FA23DB2AA77847006DE429 /* PreferenceKeys.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -799,8 +805,10 @@
 				DF3B36F521ECAF8A0033C858 /* NSError+DisplayableError.swift in Sources */,
 				FCDAFBDF27C54741001314C2 /* Fonts+Constants.generated.swift in Sources */,
 				E87A3DEE2A8AC3B90068F34C /* GroupDetailView.swift in Sources */,
+				E8C33FF82AA0E4C50004E455 /* SwipeableRowView.swift in Sources */,
 				F40191112301E7FB00CF1502 /* DecodingError+DisplayableError.swift in Sources */,
 				E87A3DFA2A8BE6F90068F34C /* GroupCardView.swift in Sources */,
+				E8FA23DC2AA77847006DE429 /* PreferenceKeys.swift in Sources */,
 				E8C33FF52A9FE04E0004E455 /* FilterView.swift in Sources */,
 				FCDAFBDB27C54741001314C2 /* PluggableApplicationDelegate.generated.swift in Sources */,
 				0F79D60A29F1F50000346E43 /* App.swift in Sources */,

--- a/CustomContacts/Code/UI/Common/PreferenceKeys.swift
+++ b/CustomContacts/Code/UI/Common/PreferenceKeys.swift
@@ -1,0 +1,14 @@
+//
+//  PreferenceKeys.swift
+//  CustomContacts
+//
+//  Created by Robert Deans on 9/5/23.
+//  Copyright © 2023 RBD. All rights reserved.
+//
+
+import SwiftUI
+
+struct FramePreferenceKey: PreferenceKey {
+	static var defaultValue: CGRect = .zero
+	static func reduce(value: inout CGRect, nextValue: () -> CGRect) {}
+}

--- a/CustomContacts/Code/UI/Common/SwipeableRowView.swift
+++ b/CustomContacts/Code/UI/Common/SwipeableRowView.swift
@@ -1,0 +1,97 @@
+//
+//  SwipeableRowView.swift
+//  CustomContacts
+//
+//  Created by Robert Deans on 8/31/23.
+//  Copyright © 2023 RBD. All rights reserved.
+//
+
+import SwiftUI
+
+private enum Layout {
+	static let buttonCoordinateSpace = "RemoveButton"
+}
+
+private struct SwipeableRowViewModifier: ViewModifier {
+	@State private var xOffset = CGFloat.zero
+	@State private var hideButton = false
+
+	@State private var swipeThreshold = CGFloat(0)
+
+	let onDelete: (() -> Void)?
+	func body(content: Content) -> some View {
+		ZStack {
+			deleteButton
+				.frame(maxWidth: .infinity, alignment: .trailing)
+				.background(Color.red)
+				// Hack for background flash on View appearing
+				.opacity(xOffset < 0 ? 1 : 0)
+				// Hack for background flash on View disappearing
+				.opacity(hideButton ? 0 : 1)
+
+			content
+				.background(Color(UIColor.systemBackground))
+				.offset(x: xOffset)
+				.gesture(
+					DragGesture()
+						.onChanged(onDragValueChanged)
+						.onEnded(onDragValueEnded)
+				)
+		}
+	}
+
+	private func onDragValueChanged(_ value: DragGesture.Value) {
+		let xOffset = value.translation.width
+		guard xOffset < .zero else {
+			return
+		}
+		self.xOffset = xOffset
+	}
+
+	private func onDragValueEnded(_ value: DragGesture.Value) {
+		withAnimation {
+			if value.translation.width < swipeThreshold {
+				xOffset = swipeThreshold
+			} else {
+				xOffset = .zero
+			}
+		}
+	}
+
+	@ViewBuilder
+	private var deleteButton: some View {
+		if let onDelete {
+			Button(
+				action: {
+					hideButton = true
+					onDelete()
+				},
+				label: {
+					Text(Localizable.Contacts.Filter.remove)
+						.tint(.white)
+						.frame(maxHeight: .infinity)
+						.padding(.horizontal, Constants.UI.Padding.default)
+				}
+			)
+			.background(
+				GeometryReader { geometry in
+					Color.clear
+						.preference(
+							key: FramePreferenceKey.self,
+							value: geometry.frame(in: .named(Layout.buttonCoordinateSpace))
+						)
+				}
+			)
+			.coordinateSpace(name: Layout.buttonCoordinateSpace)
+			.onPreferenceChange(FramePreferenceKey.self) { frame in
+				swipeThreshold = -frame.width
+			}
+		}
+	}
+}
+
+extension View {
+	func swipeable(onDelete: (() -> Void)? = nil) -> some View {
+		modifier(SwipeableRowViewModifier(onDelete: onDelete))
+	}
+}

--- a/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
@@ -56,13 +56,13 @@ struct ContactSelectorView: View {
 
 extension ContactSelectorView: Identifiable {
 	var id: String {
-		viewModel.id
+		@Dependency(\.uuid) var uuid
+		return uuid().uuidString
 	}
 }
 
 extension ContactSelectorView {
 	private final class ViewModel: ObservableObject {
-		let id: String
 		@Dependency(\.contactsRepository) private var contactsRepository
 
 		@Published private var contacts: [Contact] = []
@@ -80,9 +80,6 @@ extension ContactSelectorView {
 		}
 
 		init() {
-			@Dependency(\.uuid) var uuid
-			self.id = uuid().uuidString
-
 			Task {
 				// Contacts should already have loaded on earlier screen
 				await loadContacts()

--- a/CustomContacts/Code/UI/Main/Filter/FilterRowView.swift
+++ b/CustomContacts/Code/UI/Main/Filter/FilterRowView.swift
@@ -21,6 +21,13 @@ struct FilterRowView: View {
 	@Query(sort: [SortDescriptor(\ContactGroup.name)])
 	private var groups: [ContactGroup]
 
+	private var borderColor: Color {
+		if filterQuery.group == contactsRepository.allContactsGroup {
+			return .clear
+		}
+		return filterQuery.group.color
+	}
+
 	var body: some View {
 		Group {
 			if isFirstRow {
@@ -29,7 +36,7 @@ struct FilterRowView: View {
 				rowContentView
 			}
 		}
-		.border(filterQuery.group.color)
+		.border(borderColor)
 	}
 }
 

--- a/CustomContacts/Code/UI/Main/Filter/FilterView.swift
+++ b/CustomContacts/Code/UI/Main/Filter/FilterView.swift
@@ -34,6 +34,13 @@ struct FilterView: View {
 			Group {
 				ForEach(Array(filterQueries.enumerated()), id: \.element.id) { index, query in
 					FilterRowView(filterQuery: query, isFirstRow: index == 0)
+						.swipeable(
+							onDelete: {
+								withAnimation {
+									onRemoveQueryTapped(query)
+								}
+							}
+						)
 				}
 
 				HStack {

--- a/CustomContacts/Resources/Localization/en.lproj/Localizable.strings
+++ b/CustomContacts/Resources/Localization/en.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "Contacts.Sort.FirstNameZA" = "First name Z↔A";
 "Contacts.Sort.LastNameAZ" = "Last name A↔Z";
 "Contacts.Sort.LastNameZA" = "Last name Z↔A";
+"Contacts.Filter.Remove" = "Remove";
 
 // GROUP
 "Groups.Edit.AddRemove" = "Add/Remove Contacts";


### PR DESCRIPTION
While swiping is included within `List`, this also removed a lot of UI properties from the pickers that ultimately made `List` a poor candidate.

Instead adding a swipe gesture maintains the expected UI and roughly mimics Apple's own swiping logic. It isn't 100% perfect, but can certainly be improved in the future after in-hand testing becomes available with iOS-17 release