### PR TITLE
Refactor ContactsProvider; convert ContactsListViewModel from @Observable to ObservableObject

### DIFF
--- a/CustomContacts.xcodeproj/project.pbxproj
+++ b/CustomContacts.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		E87A3DFE2A8C139C0068F34C /* ContactGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87A3DFD2A8C139C0068F34C /* ContactGroup+Extensions.swift */; };
 		E88DA29E2AA120E2002797AB /* FilterRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DA29D2AA120E2002797AB /* FilterRowView.swift */; };
 		E88DA2A02AA12188002797AB /* FilterQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DA29F2AA12188002797AB /* FilterQuery.swift */; };
+		E8966E1F2BABD3FA00C41665 /* ContactsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8966E1E2BABD3FA00C41665 /* ContactsProviderTests.swift */; };
 		E8A497EA2AABA6F20057C78B /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A497E92AABA6F20057C78B /* Color+Extensions.swift */; };
 		E8C33FF32A9F982A0004E455 /* ContactCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF22A9F982A0004E455 /* ContactCardView.swift */; };
 		E8C33FF52A9FE04E0004E455 /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF42A9FE04E0004E455 /* FilterView.swift */; };
@@ -138,6 +139,7 @@
 		E87A3DFD2A8C139C0068F34C /* ContactGroup+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContactGroup+Extensions.swift"; sourceTree = "<group>"; };
 		E88DA29D2AA120E2002797AB /* FilterRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterRowView.swift; sourceTree = "<group>"; };
 		E88DA29F2AA12188002797AB /* FilterQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterQuery.swift; sourceTree = "<group>"; };
+		E8966E1E2BABD3FA00C41665 /* ContactsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsProviderTests.swift; sourceTree = "<group>"; };
 		E8A497E92AABA6F20057C78B /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		E8C33FF22A9F982A0004E455 /* ContactCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCardView.swift; sourceTree = "<group>"; };
 		E8C33FF42A9FE04E0004E455 /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
@@ -379,6 +381,7 @@
 			children = (
 				F4CD70402000046A0013EE7B /* Info.plist */,
 				E81C37AC2AAFAC3A00FE487F /* CustomContactsTest.swift */,
+				E8966E1E2BABD3FA00C41665 /* ContactsProviderTests.swift */,
 				E81C37AB2AAFAC3A00FE487F /* CustomContactsTests-Bridging-Header.h */,
 			);
 			path = Tests;
@@ -681,6 +684,7 @@
 				E85F50772B61B42C00E62286 /* FilterQuery.swift in Sources */,
 				E85F50742B61B34200E62286 /* ContactListViewModel.swift in Sources */,
 				E85F50792B61B44100E62286 /* ContactListNavigation.swift in Sources */,
+				E8966E1F2BABD3FA00C41665 /* ContactsProviderTests.swift in Sources */,
 				E85F50762B61B42000E62286 /* ContactsRepository.swift in Sources */,
 				E85F50802B61B4A200E62286 /* ContactGroup+Extensions.swift in Sources */,
 				5227EB492964968E004117A2 /* (null) in Sources */,

--- a/CustomContacts/Code/Repositories/ContactsProvider.swift
+++ b/CustomContacts/Code/Repositories/ContactsProvider.swift
@@ -12,6 +12,7 @@ import SwiftyUserDefaults
 
 struct ContactsProvider {
 	var sortContacts: (_ sortOption: Contact.SortOption) -> [Contact]
+	var filterContacts: ([FilterQuery]) -> [Contact]
 	var currentSortOption: () -> Contact.SortOption
 }
 
@@ -29,6 +30,47 @@ extension ContactsProvider: DependencyKey {
 			sortContacts: { sortOption in
 				Defaults[\.contactsSortOption] = sortOption
 				return contactsRepository.contacts().sorted(by: sortOption)
+			},
+			filterContacts: { filterQueries in
+				// Given the switch case and usage of Set methods, this could be more efficient.
+				// TODO: re-test with larger contacts data set and
+				// TODO: add test coverage
+
+				var filteredContactIDs = Set<Contact.ID>()
+				if !filterQueries.isEmpty {
+					filterQueries.forEach {
+						switch $0.logic {
+						case .and:
+							switch $0.filter {
+							case .include:
+								filteredContactIDs.formIntersection($0.group.contactIDs)
+							case .exclude:
+								var allContactIDsExcludingGroup = contactsRepository.contactIDs()
+								$0.group.contactIDs.forEach {
+									filteredContactIDs.remove($0)
+									allContactIDsExcludingGroup.remove($0)
+								}
+								filteredContactIDs.formUnion(allContactIDsExcludingGroup)
+							}
+						case .or:
+							switch $0.filter {
+							case .include:
+								filteredContactIDs.formUnion($0.group.contactIDs)
+							case .exclude:
+								var allContactIDsExcludingGroup = contactsRepository.contactIDs()
+								$0.group.contactIDs.forEach {
+									allContactIDsExcludingGroup.remove($0)
+								}
+								filteredContactIDs.formUnion(allContactIDsExcludingGroup)
+							}
+						}
+					}
+				} else {
+					filteredContactIDs = contactsRepository.contactIDs()
+				}
+
+				return filteredContactIDs
+					.compactMap(contactsRepository.getContact)
 			},
 			currentSortOption: { Defaults[\.contactsSortOption] }
 		)

--- a/CustomContacts/Code/UI/Main/Contacts/ContactListView.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactListView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ContactListView: View {
 	@StateObject private var contactListNavigation = ContactListNavigation()
-	@Bindable var viewModel: ViewModel
+	@StateObject var viewModel: ViewModel
 
 	var body: some View {
 		NavigationStack(path: $contactListNavigation.path) {
@@ -46,9 +46,8 @@ struct ContactListView: View {
 		} else {
 			VStack {
 /*
-
 Disable until functionality and placement can be better considered
- 
+
 				FilterView(
 					filterQueries: viewModel.filterQueries,
 					onAddQueryTapped: { viewModel.addQuery($0) },
@@ -57,7 +56,7 @@ Disable until functionality and placement can be better considered
 				)
 */
 				List {
-					ForEach(viewModel.contactsSections(), id: \.0) { letter, contacts in
+					ForEach(viewModel.contactsSections, id: \.0) { letter, contacts in
 						Section(letter.capitalized) {
 							ForEach(contacts) { contact in
 								ContactCardView(contact: contact)

--- a/CustomContacts/Code/UI/Main/Filter/FilterQuery.swift
+++ b/CustomContacts/Code/UI/Main/Filter/FilterQuery.swift
@@ -41,3 +41,10 @@ extension FilterQuery {
 		case or
 	}
 }
+
+extension FilterQuery: Equatable {
+	// TODO: revisit this when re-implementing filtering
+	static func == (lhs: FilterQuery, rhs: FilterQuery) -> Bool {
+		lhs.id == rhs.id
+	}
+}

--- a/CustomContacts/Tests/ContactsProviderTests.swift
+++ b/CustomContacts/Tests/ContactsProviderTests.swift
@@ -1,0 +1,19 @@
+//
+//  ContactsProviderTests.swift
+//  CustomContactsTests
+//
+//  Created by Robert Deans on 3/20/24.
+//  Copyright © 2024 RBD. All rights reserved.
+//
+
+import XCTest
+
+final class ContactsProviderTests: XCTestCase {
+	func testSortContacts() {
+		// Could be handled in `Contacts.sorted` extension?
+	}
+
+	func testFilterContacts() {
+
+	}
+}

--- a/CustomContacts/Tests/CustomContactsTest.swift
+++ b/CustomContacts/Tests/CustomContactsTest.swift
@@ -13,7 +13,7 @@ final class CustomContactsTest: XCTestCase {
 	func testLoadContacts() async {
 		let viewModel = ContactListView.ViewModel()
 		await viewModel.loadContacts(refresh: true)
-		XCTAssert(!viewModel.contacts.isEmpty)
+		XCTAssert(!viewModel.contactsSections.isEmpty)
 
 	}
 

--- a/Libraries/CustomContactsAPIKit/Package.swift
+++ b/Libraries/CustomContactsAPIKit/Package.swift
@@ -47,6 +47,6 @@ let package = Package(
 				"CustomContactsHelpers",
 			],
 			path: "./Models"
-		)
+		),
 	]
 )


### PR DESCRIPTION
`@Observable` lacks a lot of the features inherent to Combine, and doesn't easily convert (particularly when trying to combine three or more Publishers).

`ContactsProvider` is now simply a vessel for sorting/filtering a given array of `Contact`; further refinements will be made... eventually