### PR TITLE
Refactor sorting placement; Begin to minimize exposure to excessive contactsRepository

### DIFF
--- a/CustomContacts.xcodeproj/project.pbxproj
+++ b/CustomContacts.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		DF3B36FD21ECAF8A0033C858 /* ApplicationError+DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3B36DF21ECAF8A0033C858 /* ApplicationError+DisplayableError.swift */; };
 		DF3B370121ECAFDD0033C858 /* String+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3B370021ECAFDD0033C858 /* String+Localization.swift */; };
 		E8013AAD2B645824006CC984 /* ContactsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8013AAC2B645824006CC984 /* ContactsProvider.swift */; };
+		E80F25D02B6858FE002E4FE5 /* Contact.SortOption+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80F25CF2B6858FE002E4FE5 /* Contact.SortOption+Extensions.swift */; };
 		E81C37AD2AAFAC3A00FE487F /* ContactListViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81C37AC2AAFAC3A00FE487F /* ContactListViewModelTest.swift */; };
 		E821393C2B193A3A009ABF4E /* EdgeSwipeCardFlipModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E821393B2B193A3A009ABF4E /* EdgeSwipeCardFlipModifier.swift */; };
 		E821393E2B1A5C49009ABF4E /* ScreenSizeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E821393D2B1A5C49009ABF4E /* ScreenSizeKey.swift */; };
@@ -120,6 +121,7 @@
 		DF3B36DF21ECAF8A0033C858 /* ApplicationError+DisplayableError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ApplicationError+DisplayableError.swift"; sourceTree = "<group>"; };
 		DF3B370021ECAFDD0033C858 /* String+Localization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		E8013AAC2B645824006CC984 /* ContactsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsProvider.swift; sourceTree = "<group>"; };
+		E80F25CF2B6858FE002E4FE5 /* Contact.SortOption+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Contact.SortOption+Extensions.swift"; sourceTree = "<group>"; };
 		E81C37AB2AAFAC3A00FE487F /* CustomContactsTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CustomContactsTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		E81C37AC2AAFAC3A00FE487F /* ContactListViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactListViewModelTest.swift; sourceTree = "<group>"; };
 		E821393B2B193A3A009ABF4E /* EdgeSwipeCardFlipModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeSwipeCardFlipModifier.swift; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 			children = (
 				E8A497E92AABA6F20057C78B /* Color+Extensions.swift */,
 				E8233DD12A8695EB00D52D84 /* Contact+Extensions.swift */,
+				E80F25CF2B6858FE002E4FE5 /* Contact.SortOption+Extensions.swift */,
 				E87A3DFD2A8C139C0068F34C /* ContactGroup+Extensions.swift */,
 				DF3B36BF21ECAF560033C858 /* NSAttributedString+LocalizedFormat.swift */,
 				DF3B370021ECAFDD0033C858 /* String+Localization.swift */,
@@ -654,6 +657,7 @@
 				FCDAFBE027C54741001314C2 /* JSON.generated.swift in Sources */,
 				E8A497EA2AABA6F20057C78B /* Color+Extensions.swift in Sources */,
 				DF3B36F521ECAF8A0033C858 /* NSError+DisplayableError.swift in Sources */,
+				E80F25D02B6858FE002E4FE5 /* Contact.SortOption+Extensions.swift in Sources */,
 				FCDAFBDF27C54741001314C2 /* Fonts+Constants.generated.swift in Sources */,
 				E87A3DEE2A8AC3B90068F34C /* GroupDetailView.swift in Sources */,
 				E8C33FF82AA0E4C50004E455 /* SwipeableRowView.swift in Sources */,

--- a/CustomContacts.xcodeproj/project.pbxproj
+++ b/CustomContacts.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		DF3B36FD21ECAF8A0033C858 /* ApplicationError+DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3B36DF21ECAF8A0033C858 /* ApplicationError+DisplayableError.swift */; };
 		DF3B370121ECAFDD0033C858 /* String+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3B370021ECAFDD0033C858 /* String+Localization.swift */; };
 		E8013AAD2B645824006CC984 /* ContactsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8013AAC2B645824006CC984 /* ContactsProvider.swift */; };
-		E81C37AD2AAFAC3A00FE487F /* CustomContactsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81C37AC2AAFAC3A00FE487F /* CustomContactsTest.swift */; };
+		E81C37AD2AAFAC3A00FE487F /* ContactListViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81C37AC2AAFAC3A00FE487F /* ContactListViewModelTest.swift */; };
 		E821393C2B193A3A009ABF4E /* EdgeSwipeCardFlipModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E821393B2B193A3A009ABF4E /* EdgeSwipeCardFlipModifier.swift */; };
 		E821393E2B1A5C49009ABF4E /* ScreenSizeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E821393D2B1A5C49009ABF4E /* ScreenSizeKey.swift */; };
 		E82139402B1A7677009ABF4E /* NavigationStackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E821393F2B1A7677009ABF4E /* NavigationStackManager.swift */; };
@@ -74,6 +74,7 @@
 		E8D67B9B2A8AB21C00300FE0 /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B9A2A8AB21C00300FE0 /* ContactListView.swift */; };
 		E8D67B9D2A8AB27200300FE0 /* GroupListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B9C2A8AB27200300FE0 /* GroupListView.swift */; };
 		E8D67B9F2A8AB82A00300FE0 /* GroupCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D67B9E2A8AB82A00300FE0 /* GroupCreationView.swift */; };
+		E8DA6A032B646255000B9CB5 /* ContactsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8013AAC2B645824006CC984 /* ContactsProvider.swift */; };
 		E8FA23DC2AA77847006DE429 /* PreferenceKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8FA23DB2AA77847006DE429 /* PreferenceKeys.swift */; };
 		E8FA23DF2AA7940F006DE429 /* SwiftyUserDefaults in Frameworks */ = {isa = PBXBuildFile; productRef = E8FA23DE2AA7940F006DE429 /* SwiftyUserDefaults */; };
 		F40191112301E7FB00CF1502 /* DecodingError+DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40191102301E7FB00CF1502 /* DecodingError+DisplayableError.swift */; };
@@ -120,7 +121,7 @@
 		DF3B370021ECAFDD0033C858 /* String+Localization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		E8013AAC2B645824006CC984 /* ContactsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsProvider.swift; sourceTree = "<group>"; };
 		E81C37AB2AAFAC3A00FE487F /* CustomContactsTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CustomContactsTests-Bridging-Header.h"; sourceTree = "<group>"; };
-		E81C37AC2AAFAC3A00FE487F /* CustomContactsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomContactsTest.swift; sourceTree = "<group>"; };
+		E81C37AC2AAFAC3A00FE487F /* ContactListViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactListViewModelTest.swift; sourceTree = "<group>"; };
 		E821393B2B193A3A009ABF4E /* EdgeSwipeCardFlipModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeSwipeCardFlipModifier.swift; sourceTree = "<group>"; };
 		E821393D2B1A5C49009ABF4E /* ScreenSizeKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSizeKey.swift; sourceTree = "<group>"; };
 		E821393F2B1A7677009ABF4E /* NavigationStackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStackManager.swift; sourceTree = "<group>"; };
@@ -351,8 +352,8 @@
 			isa = PBXGroup;
 			children = (
 				FCDAFBC527C54741001314C2 /* Generated */,
-				F4CD701A200003E10013EE7B /* Application */,
 				F4CD704A200009530013EE7B /* Helpers */,
+				F4CD701A200003E10013EE7B /* Application */,
 				F4CD704B200009590013EE7B /* Repositories */,
 				F4CD7023200003E10013EE7B /* UI */,
 			);
@@ -380,7 +381,7 @@
 			isa = PBXGroup;
 			children = (
 				F4CD70402000046A0013EE7B /* Info.plist */,
-				E81C37AC2AAFAC3A00FE487F /* CustomContactsTest.swift */,
+				E81C37AC2AAFAC3A00FE487F /* ContactListViewModelTest.swift */,
 				E8966E1E2BABD3FA00C41665 /* ContactsProviderTests.swift */,
 				E81C37AB2AAFAC3A00FE487F /* CustomContactsTests-Bridging-Header.h */,
 			);
@@ -682,13 +683,14 @@
 				E85F50822B61B4CA00E62286 /* Constants.swift in Sources */,
 				E85F507F2B61B49700E62286 /* ContactCardView.swift in Sources */,
 				E85F50772B61B42C00E62286 /* FilterQuery.swift in Sources */,
+				E8DA6A032B646255000B9CB5 /* ContactsProvider.swift in Sources */,
 				E85F50742B61B34200E62286 /* ContactListViewModel.swift in Sources */,
 				E85F50792B61B44100E62286 /* ContactListNavigation.swift in Sources */,
 				E8966E1F2BABD3FA00C41665 /* ContactsProviderTests.swift in Sources */,
 				E85F50762B61B42000E62286 /* ContactsRepository.swift in Sources */,
 				E85F50802B61B4A200E62286 /* ContactGroup+Extensions.swift in Sources */,
 				5227EB492964968E004117A2 /* (null) in Sources */,
-				E81C37AD2AAFAC3A00FE487F /* CustomContactsTest.swift in Sources */,
+				E81C37AD2AAFAC3A00FE487F /* ContactListViewModelTest.swift in Sources */,
 				E85F507A2B61B44F00E62286 /* NavigationStackManager.swift in Sources */,
 				E85F507D2B61B48900E62286 /* NSAttributedString+LocalizedFormat.swift in Sources */,
 				E85F50812B61B4C100E62286 /* Color+Extensions.swift in Sources */,

--- a/CustomContacts/Code/Helpers/Extensions/Contact+Extensions.swift
+++ b/CustomContacts/Code/Helpers/Extensions/Contact+Extensions.swift
@@ -9,13 +9,6 @@
 import CustomContactsModels
 import Dependencies
 
-extension Contact.SortOption {
-	static var current: Contact.SortOption {
-		@Dependency(\.contactsProvider) var contactsProvider
-		return contactsProvider.currentSortOption()
-	}
-}
-
 extension Sequence where Element == Contact {
 	func sorted(by sortOption: Contact.SortOption = .current) -> [Contact] {
 		switch sortOption.parameter {

--- a/CustomContacts/Code/Helpers/Extensions/Contact.SortOption+Extensions.swift
+++ b/CustomContacts/Code/Helpers/Extensions/Contact.SortOption+Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  Contact.SortOption+Extensions.swift
+//  CustomContacts
+//
+//  Created by Robert Deans on 1/29/24.
+//  Copyright © 2024 RBD. All rights reserved.
+//
+
+import CustomContactsModels
+import SwiftyUserDefaults
+
+extension Contact.SortOption: DefaultsSerializable {
+	static var current: Contact.SortOption {
+		Defaults[\.contactsSortOption]
+	}
+}
+
+extension DefaultsKeys {
+	var contactsSortOption: DefaultsKey<Contact.SortOption> {
+		.init(
+			"contactsSortOption",
+			defaultValue: Contact.SortOption(parameter: .lastName, ascending: true)
+		)
+	}
+}

--- a/CustomContacts/Code/Helpers/Extensions/ContactGroup+Extensions.swift
+++ b/CustomContacts/Code/Helpers/Extensions/ContactGroup+Extensions.swift
@@ -31,8 +31,14 @@ extension ContactGroup {
 		return ContactGroup(
 			id: "",
 			name: "All Contacts",
-			contactIDs: contactsRepository.contactIDs(),
+			contactIDs: Set(contactsRepository.contacts().map { $0.id }),
 			colorHex: ""
 		)
+	}
+
+	func contacts() -> [Contact] {
+		@Dependency(\.contactsRepository) var contactsRepository
+		return self.contactIDs
+			.compactMap { contactsRepository.getContact($0) }
 	}
 }

--- a/CustomContacts/Code/Repositories/ContactsProvider.swift
+++ b/CustomContacts/Code/Repositories/ContactsProvider.swift
@@ -74,6 +74,7 @@ extension ContactsProvider: DependencyKey {
 			currentSortOption: { Defaults[\.contactsSortOption] }
 		)
 	}
+	static var testValue: ContactsProvider = .liveValue
 }
 
 extension Contact.SortOption: DefaultsSerializable {}

--- a/CustomContacts/Code/Repositories/ContactsProvider.swift
+++ b/CustomContacts/Code/Repositories/ContactsProvider.swift
@@ -13,7 +13,6 @@ import SwiftyUserDefaults
 struct ContactsProvider {
 	var sortContacts: ([Contact], Contact.SortOption) -> [Contact]
 	var filterContacts: (Set<Contact.ID>, [FilterQuery]) -> [Contact]
-	var currentSortOption: () -> Contact.SortOption
 }
 
 extension DependencyValues {
@@ -70,20 +69,8 @@ extension ContactsProvider: DependencyKey {
 				@Dependency(\.contactsRepository) var contactsRepository
 				return filteredContactIDs
 					.compactMap(contactsRepository.getContact)
-			},
-			currentSortOption: { Defaults[\.contactsSortOption] }
+			}
 		)
 	}
 	static var testValue: ContactsProvider = .liveValue
-}
-
-extension Contact.SortOption: DefaultsSerializable {}
-
-extension DefaultsKeys {
-	fileprivate var contactsSortOption: DefaultsKey<Contact.SortOption> {
-		.init(
-			"contactsSortOption",
-			defaultValue: Contact.SortOption(parameter: .lastName, ascending: true)
-		)
-	}
 }

--- a/CustomContacts/Code/Repositories/ContactsRepository.swift
+++ b/CustomContacts/Code/Repositories/ContactsRepository.swift
@@ -59,7 +59,7 @@ extension ContactsRepository: DependencyKey {
 			contacts: { _contacts }
 		)
 	}
-	static var testValue: Self {
+	static var previewValue: Self {
 		Self(
 			getAllContacts: { _ in Contact.mockArray },
 			getContact: { _ in Contact.mock },
@@ -67,5 +67,5 @@ extension ContactsRepository: DependencyKey {
 			contacts: { Contact.mockArray }
 		)
 	}
-	static var previewValue = Self.testValue
+	static var testValue: ContactsRepository = .liveValue
 }

--- a/CustomContacts/Code/Repositories/ContactsRepository.swift
+++ b/CustomContacts/Code/Repositories/ContactsRepository.swift
@@ -12,9 +12,15 @@ import CustomContactsService
 import Dependencies
 
 struct ContactsRepository {
+	/// Returns an array `[Contact]`
+	///
+	/// If `refresh: true` the array is fetched from ContactsService, otherwise the locally stored array is provided
 	var getAllContacts: (_ refresh: Bool) async throws -> [Contact]
+
+	/// Fetches a contact from a local dictionary; O(1) lookup time
 	var getContact: (_ id: Contact.ID) -> Contact?
-	var contactIDs: () -> Set<Contact.ID>
+
+	/// Returns a local array of `[Contact]`; no conversions or computations
 	var contacts: () -> [Contact]
 }
 
@@ -31,7 +37,6 @@ extension ContactsRepository: DependencyKey {
 
 		// swiftlint:disable identifier_name
 		var _contacts: [Contact] = []
-		var contactIDsSet: Set<Contact.ID> = []
 		var contactDictionary: [Contact.ID: Contact] = [:]
 
 		return Self(
@@ -44,7 +49,6 @@ extension ContactsRepository: DependencyKey {
 					return []
 				}
 				_contacts = try await contactsService.fetchContacts()
-				contactIDsSet = Set(_contacts.map { $0.id })
 				contactDictionary = Dictionary(
 					_contacts.map { ($0.id, $0) },
 					uniquingKeysWith: { _, last in last }
@@ -52,10 +56,7 @@ extension ContactsRepository: DependencyKey {
 				LogInfo("Repository returning \(_contacts.count) contact(s)")
 				return _contacts
 			},
-			getContact: { id in
-				contactDictionary[id]
-			},
-			contactIDs: { contactIDsSet },
+			getContact: { contactDictionary[$0] },
 			contacts: { _contacts }
 		)
 	}
@@ -63,7 +64,6 @@ extension ContactsRepository: DependencyKey {
 		Self(
 			getAllContacts: { _ in Contact.mockArray },
 			getContact: { _ in Contact.mock },
-			contactIDs: { [] },
 			contacts: { Contact.mockArray }
 		)
 	}

--- a/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
@@ -65,8 +65,6 @@ extension ContactSelectorView: Identifiable {
 extension ContactSelectorView {
 	// Could be `private` if not for Xcode warnings re: @Observable
 	@Observable final class ViewModel {
-		@ObservationIgnored @Dependency(\.contactsRepository) private var contactsRepository
-
 		private var contacts: [Contact] = []
 		var searchText = ""
 		private(set) var error: Error?
@@ -84,6 +82,7 @@ extension ContactSelectorView {
 
 		@MainActor func loadContacts(refresh: Bool = false) async {
 			do {
+				@Dependency(\.contactsRepository) var contactsRepository
 				contacts = try await contactsRepository.getAllContacts(refresh)
 			} catch {
 				self.error = error

--- a/CustomContacts/Code/UI/Main/Groups/GroupCardView.swift
+++ b/CustomContacts/Code/UI/Main/Groups/GroupCardView.swift
@@ -7,26 +7,25 @@
 //
 
 import CustomContactsModels
-import Dependencies
 import SwiftUI
 
 struct GroupCardView: View {
 	@EnvironmentObject private var groupNavigation: GroupListNavigation
-	@Dependency(\.contactsRepository) private var contactsRepository
-	let group: ContactGroup
-	let onGroupTapped: () -> Void
-
 	@State private var isExpanded = false
+
+	private let group: ContactGroup
+	private let onGroupTapped: () -> Void
+
+	init(group: ContactGroup, onGroupTapped: @escaping () -> Void) {
+		self.group = group
+		self.onGroupTapped = onGroupTapped
+	}
 
 	var body: some View {
 		DisclosureGroup(
 			isExpanded: $isExpanded,
 			content: {
-				ForEach(
-					group.contactIDs
-						.compactMap { contactsRepository.getContact($0) }
-						.sorted()
-				) { contact in
+				ForEach(group.contacts().sorted()) { contact in
 					Button(
 						action: {
 							groupNavigation.path.append(.contactDetail(contact))

--- a/CustomContacts/Code/UI/Main/Groups/GroupDetailView.swift
+++ b/CustomContacts/Code/UI/Main/Groups/GroupDetailView.swift
@@ -67,11 +67,7 @@ struct GroupDetailView: View {
 			}
 
 			List {
-				ForEach(
-					group.contactIDs
-						.compactMap { contactsRepository.getContact($0) }
-						.sorted()
-				) {
+				ForEach(group.contacts().sorted()) {
 					Text($0.displayName)
 				}
 			}

--- a/CustomContacts/Tests/ContactListViewModelTest.swift
+++ b/CustomContacts/Tests/ContactListViewModelTest.swift
@@ -1,17 +1,25 @@
 //
-//  CustomContactsTest.swift
+//  ContactListViewModelTest.swift
 //  CustomContactsTests
 //
 //  Created by Robert Deans on 9/11/23.
 //  Copyright © 2023 RBD. All rights reserved.
 //
 
+import CustomContactsModels
 import Dependencies
 import XCTest
 
-final class CustomContactsTest: XCTestCase {
+final class ContactListViewModelTest: XCTestCase {
 	func testLoadContacts() async {
-		let viewModel = ContactListView.ViewModel()
+		let viewModel = withDependencies {
+			$0.contactsService.fetchContacts = {
+				Contact.mockArray
+			}
+		} operation: {
+			ContactListView.ViewModel()
+		}
+		// Test isLoading??
 		await viewModel.loadContacts(refresh: true)
 		XCTAssert(!viewModel.contactsSections.isEmpty)
 


### PR DESCRIPTION
- Store sorting setting within `Contact.SortOption.current`
- Begin to refactor Groups to allow more flexibility away from `ContactsRepository` reliance