### PR TITLE
chore(api-kit/helper): adopt Swift concurrency check for API and Helper libraries

### DIFF
--- a/CustomContacts/Code/Helpers/ContactGroupHandler.swift
+++ b/CustomContacts/Code/Helpers/ContactGroupHandler.swift
@@ -19,7 +19,7 @@ actor ContactGroupHandler {
 		contactIDs: Set<Contact.ID>,
 		colorHex: String
 	) throws -> PersistentIdentifier {
-		PrintCurrentThread("ContactGroupHandler")
+		LogCurrentThread("ContactGroupHandler")
 
 		@Dependency(\.uuid) var uuid
 

--- a/CustomContacts/Code/UI/Main/Groups/GroupCreationView.swift
+++ b/CustomContacts/Code/UI/Main/Groups/GroupCreationView.swift
@@ -94,7 +94,7 @@ struct GroupCreationView: View {
 	/// and action is immediately related to user actions
 	private func createGroup() {
 		Task(priority: .userInitiated) {
-			PrintCurrentThread("createGroup")
+			LogCurrentThread("createGroup")
 			do {
 				let container = modelContext.container
 				let handler = ContactGroupHandler(modelContainer: container)

--- a/Libraries/CustomContactsAPIKit/Package.swift
+++ b/Libraries/CustomContactsAPIKit/Package.swift
@@ -39,14 +39,20 @@ let package = Package(
 				"CustomContactsHelpers",
 				"CustomContactsModels",
 			],
-			path: "./Service"
+			path: "./Service",
+			swiftSettings: [
+				.enableExperimentalFeature("StrictConcurrency"),
+			]
 		),
 		.target(
 			name: "CustomContactsModels",
 			dependencies: [
 				"CustomContactsHelpers",
 			],
-			path: "./Models"
+			path: "./Models",
+			swiftSettings: [
+				.enableExperimentalFeature("StrictConcurrency"),
+			]
 		),
 	]
 )

--- a/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
+++ b/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
@@ -10,46 +10,8 @@ import Contacts
 import CustomContactsHelpers
 import CustomContactsModels
 
-extension ContactsService {
-	public static var liveValue: Self {
-		Self(
-			fetchContacts: {
-				let request = CNContactFetchRequest(keysToFetch: Self.keysToFetch.compactMap { $0 as? CNKeyDescriptor })
-				return try await withCheckedThrowingContinuation { continuation in
-					do {
-						var contacts: [Contact] = []
-						let store = CNContactStore()
-						try store.enumerateContacts(with: request) { cnContact, _ in
-							contacts.append(Contact(cnContact))
-						}
-						LogInfo("Service returning \(contacts.count) contact(s)")
-						continuation.resume(returning: contacts)
-					} catch {
-						continuation.resume(throwing: error)
-					}
-				}
-			},
-			requestPermissions: {
-				let contactsAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
-				switch contactsAuthorizationStatus {
-				case .authorized:
-					return true
-				case .notDetermined:
-					do {
-						let store = CNContactStore()
-						return try await store.requestAccess(for: .contacts)
-					} catch {
-						throw error
-					}
-				case .restricted, .denied:
-					return false
-				@unknown default:
-					LogWarning("Unknown Contact permissions case: \(contactsAuthorizationStatus)")
-					return false
-				}
-			}
-		)
-	}
+private actor ContactStoreHandler {
+	private lazy var store = CNContactStore()
 
 	private static var keysToFetch: [Any] {
 		[
@@ -63,5 +25,55 @@ extension ContactsService {
 			CNContactPostalAddressesKey,
 			CNContactPhoneNumbersKey,
 		]
+	}
+
+	func fetchContacts() async throws -> [Contact] {
+		let request = CNContactFetchRequest(keysToFetch: Self.keysToFetch.compactMap { $0 as? CNKeyDescriptor })
+		return try await withCheckedThrowingContinuation { continuation in
+			do {
+				var contacts: [Contact] = []
+				try store.enumerateContacts(with: request) { cnContact, _ in
+					contacts.append(Contact(cnContact))
+				}
+				LogInfo("Service returning \(contacts.count) contact(s)")
+				continuation.resume(returning: contacts)
+			} catch {
+				continuation.resume(throwing: error)
+			}
+		}
+	}
+	func requestPermissions() async throws -> Bool {
+		let contactsAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
+		switch contactsAuthorizationStatus {
+		case .authorized:
+			return true
+		case .notDetermined:
+			do {
+				return try await store.requestAccess(for: .contacts)
+			} catch {
+				throw error
+			}
+		case .restricted, .denied:
+			return false
+		@unknown default:
+			LogWarning("Unknown Contact permissions case: \(contactsAuthorizationStatus)")
+			return false
+		}
+	}
+}
+
+extension ContactsService {
+	// Possible improvement for syncing:
+	// https://developer.apple.com/documentation/foundation/nsnotification/name/1403253-cncontactstoredidchange
+	public static var liveValue: Self {
+		let contactsHandler = ContactStoreHandler()
+		return Self(
+			fetchContacts: {
+				try await contactsHandler.fetchContacts()
+			},
+			requestPermissions: {
+				try await contactsHandler.requestPermissions()
+			}
+		)
 	}
 }

--- a/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
+++ b/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
@@ -12,25 +12,13 @@ import CustomContactsModels
 
 extension ContactsService {
 	public static var liveValue: Self {
-		let store = CNContactStore()
-		let keysToFetch: [Any] = [
-			CNContactIdentifierKey,
-			CNContactTypeKey,
-			CNContactGivenNameKey,
-			CNContactFamilyNameKey,
-			CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
-			CNContactOrganizationNameKey,
-			CNContactEmailAddressesKey,
-			CNContactPostalAddressesKey,
-			CNContactPhoneNumbersKey,
-		]
-
-		return Self(
+		Self(
 			fetchContacts: {
-				let request = CNContactFetchRequest(keysToFetch: keysToFetch.compactMap { $0 as? CNKeyDescriptor })
+				let request = CNContactFetchRequest(keysToFetch: Self.keysToFetch.compactMap { $0 as? CNKeyDescriptor })
 				return try await withCheckedThrowingContinuation { continuation in
 					do {
 						var contacts: [Contact] = []
+						let store = CNContactStore()
 						try store.enumerateContacts(with: request) { cnContact, _ in
 							contacts.append(Contact(cnContact))
 						}
@@ -48,6 +36,7 @@ extension ContactsService {
 					return true
 				case .notDetermined:
 					do {
+						let store = CNContactStore()
 						return try await store.requestAccess(for: .contacts)
 					} catch {
 						throw error
@@ -60,5 +49,19 @@ extension ContactsService {
 				}
 			}
 		)
+	}
+
+	private static var keysToFetch: [Any] {
+		[
+			CNContactIdentifierKey,
+			CNContactTypeKey,
+			CNContactGivenNameKey,
+			CNContactFamilyNameKey,
+			CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+			CNContactOrganizationNameKey,
+			CNContactEmailAddressesKey,
+			CNContactPostalAddressesKey,
+			CNContactPhoneNumbersKey,
+		]
 	}
 }

--- a/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
+++ b/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
@@ -28,6 +28,7 @@ private actor ContactStoreHandler {
 	}
 
 	func fetchContacts() async throws -> [Contact] {
+		LogCurrentThread("ContactStoreHandler.fetchContacts")
 		let request = CNContactFetchRequest(keysToFetch: Self.keysToFetch.compactMap { $0 as? CNKeyDescriptor })
 		return try await withCheckedThrowingContinuation { continuation in
 			do {
@@ -43,6 +44,7 @@ private actor ContactStoreHandler {
 		}
 	}
 	func requestPermissions() async throws -> Bool {
+		LogCurrentThread("ContactStoreHandler.requestPermissions")
 		let contactsAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
 		switch contactsAuthorizationStatus {
 		case .authorized:

--- a/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService.swift
+++ b/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService.swift
@@ -16,7 +16,7 @@ extension DependencyValues {
 	}
 }
 
-public struct ContactsService: DependencyKey {
-	public var fetchContacts: () async throws -> [Contact]
-	public var requestPermissions: () async throws -> Bool
+public struct ContactsService: DependencyKey, Sendable {
+	public var fetchContacts: @Sendable () async throws -> [Contact]
+	public var requestPermissions: @Sendable () async throws -> Bool
 }

--- a/Libraries/CustomContactsAPIKit/Service/Internal/CurrentModule.swift
+++ b/Libraries/CustomContactsAPIKit/Service/Internal/CurrentModule.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum CurrentModule {
-	static var name: String = {
+	static let name: String = {
 		let fullName = String(reflecting: CurrentModule.self)
 		if let nameRange = fullName.range(of: "CurrentModule", options: .backwards, range: nil, locale: nil) {
 			return String(fullName[..<fullName.index(nameRange.lowerBound, offsetBy: -1)])

--- a/Libraries/CustomContactsHelpers/Package.swift
+++ b/Libraries/CustomContactsHelpers/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 //  Package.swift
@@ -13,7 +13,7 @@ import PackageDescription
 let package = Package(
 	name: "CustomContactsHelpers",
 	platforms: [
-		.macOS(.v11), .iOS(.v14), .tvOS(.v9), .watchOS(.v2),
+		.macOS(.v11), .iOS(.v14), .tvOS(.v12), .watchOS(.v4),
 	],
 	products: [
 		.library(
@@ -30,7 +30,10 @@ let package = Package(
 			dependencies: [
 				"KeychainAccess",
 			],
-			path: "Sources"
+			path: "Sources",
+			swiftSettings: [
+				.enableExperimentalFeature("StrictConcurrency"),
+			]
 		),
 	]
 )

--- a/Libraries/CustomContactsHelpers/Sources/Components/NavigationStackView.swift
+++ b/Libraries/CustomContactsHelpers/Sources/Components/NavigationStackView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // Required to infer Path datatype in case path param is not provided by caller
 public let emptyPath: [Int] = []
 
+@MainActor
 public struct NavigationStackView<Content: View, Path: Hashable>: View {
 	@Binding var path: [Path]
 	@ViewBuilder let contentView: () -> Content

--- a/Libraries/CustomContactsHelpers/Sources/Extensions/Keychain+Shared.swift
+++ b/Libraries/CustomContactsHelpers/Sources/Extensions/Keychain+Shared.swift
@@ -9,5 +9,5 @@
 import KeychainAccess
 
 extension Keychain {
-	public static let shared = Keychain(service: "com.robertdeans.CustomContacts")
+	public static var shared: Keychain { Keychain(service: "com.robertdeans.CustomContacts") }
 }

--- a/Libraries/CustomContactsHelpers/Sources/Internal/Logging.swift
+++ b/Libraries/CustomContactsHelpers/Sources/Internal/Logging.swift
@@ -10,7 +10,7 @@
 
 import OSLog
 
-public func PrintCurrentThread(_ message: @escaping @autoclosure () -> String) {
+public func LogCurrentThread(_ message: @escaping @autoclosure () -> String) {
 	Logger().trace("🧵 \(message()): \(String(cString: __dispatch_queue_get_label(nil)))")
 }
 


### PR DESCRIPTION
- Introduces an `actor` that wraps `CNContactStore` and performs async operations to pass along to `ContactsService`

Exploring the difference between declaring an `actor` and injecting within a Dependency as mentioned [here](https://github.com/pointfreeco/swift-dependencies/discussions/41), and potentially using an `actor` directly as a Dependency (which may not work with overriding values)