### PR TITLE
Refactor/concurrency repository

### DIFF
--- a/CustomContacts.xcodeproj/project.pbxproj
+++ b/CustomContacts.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		E8A497EA2AABA6F20057C78B /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A497E92AABA6F20057C78B /* Color+Extensions.swift */; };
 		E8B431D42BB36AFC004E7616 /* ContactGroupHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B431D32BB36AFC004E7616 /* ContactGroupHandler.swift */; };
 		E8B431DA2BB5B789004E7616 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B431D92BB5B789004E7616 /* UserSettings.swift */; };
+		E8B431D82BB4B900004E7616 /* GroupCreationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B431D72BB4B900004E7616 /* GroupCreationViewModel.swift */; };
 		E8C33FF32A9F982A0004E455 /* ContactCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF22A9F982A0004E455 /* ContactCardView.swift */; };
 		E8C33FF52A9FE04E0004E455 /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF42A9FE04E0004E455 /* FilterView.swift */; };
 		E8C33FF82AA0E4C50004E455 /* SwipeableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C33FF72AA0E4C50004E455 /* SwipeableRowView.swift */; };
@@ -145,6 +146,7 @@
 		E8A497E92AABA6F20057C78B /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		E8B431D32BB36AFC004E7616 /* ContactGroupHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactGroupHandler.swift; sourceTree = "<group>"; };
 		E8B431D92BB5B789004E7616 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
+		E8B431D72BB4B900004E7616 /* GroupCreationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCreationViewModel.swift; sourceTree = "<group>"; };
 		E8C33FF22A9F982A0004E455 /* ContactCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCardView.swift; sourceTree = "<group>"; };
 		E8C33FF42A9FE04E0004E455 /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
 		E8C33FF72AA0E4C50004E455 /* SwipeableRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableRowView.swift; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 				E8D67B9C2A8AB27200300FE0 /* GroupListView.swift */,
 				E87A3DF92A8BE6F90068F34C /* GroupCardView.swift */,
 				E8D67B9E2A8AB82A00300FE0 /* GroupCreationView.swift */,
+				E8B431D72BB4B900004E7616 /* GroupCreationViewModel.swift */,
 				E87A3DED2A8AC3B90068F34C /* GroupDetailView.swift */,
 			);
 			path = Groups;
@@ -632,6 +635,7 @@
 				DF3B36C021ECAF560033C858 /* NSAttributedString+LocalizedFormat.swift in Sources */,
 				E82139422B1A76B2009ABF4E /* ContactListNavigation.swift in Sources */,
 				E8D67B9D2A8AB27200300FE0 /* GroupListView.swift in Sources */,
+				E8B431D82BB4B900004E7616 /* GroupCreationViewModel.swift in Sources */,
 				E8233DD22A8695EB00D52D84 /* Contact+Extensions.swift in Sources */,
 				E8D67B9B2A8AB21C00300FE0 /* ContactListView.swift in Sources */,
 				E8C33FF32A9F982A0004E455 /* ContactCardView.swift in Sources */,

--- a/CustomContacts/Code/Helpers/Extensions/ContactGroup+Extensions.swift
+++ b/CustomContacts/Code/Helpers/Extensions/ContactGroup+Extensions.swift
@@ -31,14 +31,17 @@ extension ContactGroup {
 		return ContactGroup(
 			id: "",
 			name: "All Contacts",
-			contactIDs: Set(contactsRepository.contacts().map { $0.id }),
+			contactIDs: [], //Set(contactsRepository.getContacts().map { $0.id }),
 			colorHex: ""
 		)
 	}
 
 	func contacts() -> [Contact] {
-		@Dependency(\.contactsRepository) var contactsRepository
-		return self.contactIDs
-			.compactMap { contactsRepository.getContact($0) }
+		[]
+//		@Dependency(\.contactsRepository) var contactsRepository
+//		return self.contactIDs
+//			.compactMap { await contactsRepository.getContact($0) }
 	}
 }
+
+// TODO: fix stuff here... getContacts()

--- a/CustomContacts/Code/Repositories/ContactsProvider.swift
+++ b/CustomContacts/Code/Repositories/ContactsProvider.swift
@@ -11,7 +11,7 @@ import Dependencies
 
 struct ContactsProvider: Sendable {
 	var sortContacts: @Sendable ([Contact], Contact.SortOption) -> [Contact]
-	var filterContacts: @Sendable (Set<Contact.ID>, [FilterQuery]) -> [Contact]
+	var filterContacts: @Sendable ([Contact], [FilterQuery]) -> [Contact]
 }
 
 extension DependencyValues {
@@ -29,10 +29,11 @@ extension ContactsProvider: DependencyKey {
 				userSettings.setSortOption(sortOption)
 				return contacts.sorted(by: sortOption)
 			},
-			filterContacts: { contactIDs, filterQueries in
+			filterContacts: { contacts, filterQueries in
 				// Given the switch case and usage of Set methods, this could be more efficient.
 				// TODO: re-test with larger contacts data set and
 
+				let contactIDs = Set(contacts.map { $0.id })
 				var filteredContactIDs = Set<Contact.ID>()
 				if !filterQueries.isEmpty {
 					filterQueries.forEach {
@@ -66,9 +67,11 @@ extension ContactsProvider: DependencyKey {
 					filteredContactIDs = contactIDs
 				}
 
-				@Dependency(\.contactsRepository) var contactsRepository
-				return filteredContactIDs
-					.compactMap(contactsRepository.getContact)
+				return contacts
+				// TODO: fix stuff here too
+//				@Dependency(\.contactsRepository) var contactsRepository
+//				return filteredContactIDs
+//					.compactMap(contactsRepository.getContact)
 			}
 		)
 	}

--- a/CustomContacts/Code/Repositories/ContactsRepository.swift
+++ b/CustomContacts/Code/Repositories/ContactsRepository.swift
@@ -11,62 +11,65 @@ import CustomContactsModels
 import CustomContactsService
 import Dependencies
 
-struct ContactsRepository: Sendable {
+protocol ContactsRepository: Sendable {
+	func fetchContacts(refresh: Bool) async throws -> [Contact]
+	func getContacts() async -> [Contact]
+	func getContact(_ id: Contact.ID) async -> Contact?
+}
+
+actor ContactsRepositoryLive: ContactsRepository {
+	private var contacts: [Contact] = []
+	private var contactDictionary: [Contact.ID: Contact] = [:]
+
 	/// Returns an array `[Contact]`
 	///
 	/// If `refresh: true` the array is fetched from ContactsService, otherwise the locally stored array is provided
-	var getAllContacts: @Sendable (_ refresh: Bool) async throws -> [Contact]
+	func fetchContacts(refresh: Bool) async throws -> [Contact] {
+		LogCurrentThread("ContactsRepositoryLive.fetchContacts")
+		guard refresh || contacts.isEmpty else {
+			return contacts
+		}
+		@Dependency(\.contactsService) var contactsService
+		guard try await contactsService.requestPermissions() else {
+			// TODO: Permissions denied state; throw error?
+			return []
+		}
+		let fetchContactsTask = Task(priority: .background) {
+			LogCurrentThread("ContactsRepositoryLive.fetchContactsTask")
+
+			// TODO: minimize re-declaration of `contactsService`?
+			@Dependency(\.contactsService) var contactsService
+			contacts = try await contactsService.fetchContacts()
+			contactDictionary = Dictionary(
+				contacts.map { ($0.id, $0) },
+				uniquingKeysWith: { _, last in last }
+			)
+			LogInfo("Repository returning \(self.contacts.count) contact(s)")
+			return contacts
+		}
+		return try await fetchContactsTask.value
+	}
+
+	/// Returns contacts that have already been fetched; no throwing
+	func getContacts() -> [Contact] {
+		contacts
+	}
 
 	/// Fetches a contact from a local dictionary; O(1) lookup time
-	var getContact: @Sendable (_ id: Contact.ID) -> Contact?
-
-	/// Returns a local array of `[Contact]`; no conversions or computations
-	var contacts: @Sendable () -> [Contact]
+	func getContact(_ id: Contact.ID) -> Contact? {
+		contactDictionary[id]
+	}
 }
 
 extension DependencyValues {
 	var contactsRepository: ContactsRepository {
-		get { self[ContactsRepository.self] }
-		set { self[ContactsRepository.self] = newValue }
+		get { self[ContactsRepositoryKey.self] }
+		set { self[ContactsRepositoryKey.self] = newValue }
 	}
 }
 
-extension ContactsRepository: DependencyKey {
-	static var liveValue: Self {
-		@Dependency(\.contactsService) var contactsService
-
-		// swiftlint:disable identifier_name
-		//var _contacts: [Contact] = []
-		//var contactDictionary: [Contact.ID: Contact] = [:]
-
-		return Self(
-			getAllContacts: { refresh in
-				guard refresh else { //} || _contacts.isEmpty else {
-					return [] //_contacts
-				}
-				return []
-//				guard try await contactsService.requestPermissions() else {
-//					// Permissions denied state; throw error?
-//					return _contacts
-//				}
-//				_contacts = try await contactsService.fetchContacts()
-//				contactDictionary = Dictionary(
-//					_contacts.map { ($0.id, $0) },
-//					uniquingKeysWith: { _, last in last }
-//				)
-//				LogInfo("Repository returning \(_contacts.count) contact(s)")
-//				return _contacts
-			},
-			getContact: { _ in nil }, //contactDictionary[$0] },
-			contacts: { [] } // _contacts }
-		)
+private enum ContactsRepositoryKey: DependencyKey {
+	static var liveValue: ContactsRepository {
+		ContactsRepositoryLive()
 	}
-	static var previewValue: Self {
-		Self(
-			getAllContacts: { _ in Contact.mockArray },
-			getContact: { _ in Contact.mock },
-			contacts: { Contact.mockArray }
-		)
-	}
-	// static var testValue: ContactsRepository = .liveValue
 }

--- a/CustomContacts/Code/UI/Main/Contacts/ContactListViewModel.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactListViewModel.swift
@@ -49,7 +49,7 @@ extension ContactListView {
 
 			do {
 				@Dependency(\.contactsRepository) var contactsRepository
-				contacts = try await contactsRepository.getAllContacts(refresh)
+				contacts = try await contactsRepository.fetchContacts(refresh: refresh)
 			} catch {
 				self.error = error
 			}
@@ -64,8 +64,7 @@ extension ContactListView.ViewModel {
 		filterQueries: [FilterQuery]
 	) -> [(String, [Contact])] {
 		@Dependency(\.contactsProvider) var contactsProvider
-		let contactIDs = Set(contacts.map { $0.id })
-		let contactsDisplayable = contactsProvider.filterContacts(contactIDs, filterQueries)
+		let contactsDisplayable = contactsProvider.filterContacts(contacts, filterQueries)
 			.filter(searchText: searchText)
 
 		var valueDictionary: [String: [Contact]] = [:]

--- a/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
+++ b/CustomContacts/Code/UI/Main/Contacts/ContactSelectorView.swift
@@ -79,7 +79,7 @@ extension ContactSelectorView {
 		@MainActor func loadContacts(refresh: Bool = false) async {
 			do {
 				@Dependency(\.contactsRepository) var contactsRepository
-				contacts = try await contactsRepository.getAllContacts(refresh)
+				contacts = try await contactsRepository.fetchContacts(refresh: refresh)
 			} catch {
 				self.error = error
 			}

--- a/CustomContacts/Code/UI/Main/Groups/GroupCreationViewModel.swift
+++ b/CustomContacts/Code/UI/Main/Groups/GroupCreationViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  GroupCreationViewModel.swift
+//  CustomContacts
+//
+//  Created by Robert Deans on 3/27/24.
+//  Copyright © 2024 RBD. All rights reserved.
+//
+
+import CustomContactsHelpers
+import CustomContactsModels
+import Dependencies
+import Observation
+import SwiftData
+import SwiftUI
+
+extension GroupCreationView {
+	@Observable @MainActor
+	final class ViewModel {
+		var name = ""
+		var color = Color.random
+		@ObservationIgnored
+		var selectedContactIDs: Set<Contact.ID> {
+			Set(selectedContacts.map { $0.id })
+		}
+		private(set) var selectedContacts: [Contact] = []
+
+		var showError = false
+
+		func updateSelectedContacts(ids: Set<Contact.ID>) async {
+			@Dependency(\.contactsRepository) var contactsRepository
+			var contacts: [Contact] = []
+			// TODO: should this alert if Contact ID is not found in dictionary? That should never happen...
+			await withTaskGroup(of: Optional<Contact>.self) { group in
+				for contactID in ids {
+					group.addTask {
+						return await contactsRepository.getContact(contactID)
+					}
+				}
+				for await contact in group {
+					if let contact {
+						contacts.append(contact)
+					}
+				}
+				selectedContacts = contacts
+					.sorted(by: { $0.displayName < $1.displayName })
+			}
+		}
+	}
+}
+
+extension GroupCreationView.ViewModel {
+	/// Saves `ContactGroup` on main thread as this is a light data load
+	/// and action is immediately related to user actions
+	func createGroup(onCompletion: @escaping () -> Void) {
+		Task(priority: .userInitiated) {
+			LogCurrentThread("createGroup")
+			do {
+				let container = try ModelContainer(for: ContactGroup.self)
+				let handler = ContactGroupHandler(modelContainer: container)
+
+				let groupID = try await handler.createGroup(
+					name: name,
+					contactIDs: selectedContactIDs,
+					colorHex: color.toHex ?? ""
+				)
+				LogInfo("Group created: \(groupID)")
+				onCompletion()
+			} catch {
+				LogError("Group creation failed: \(error.localizedDescription)")
+				showError = true
+			}
+		}
+	}
+}

--- a/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
+++ b/Libraries/CustomContactsAPIKit/Service/Dependencies/ContactsService/ContactsService+Live.swift
@@ -36,7 +36,7 @@ private actor ContactStoreHandler {
 				try store.enumerateContacts(with: request) { cnContact, _ in
 					contacts.append(Contact(cnContact))
 				}
-				LogInfo("Service returning \(contacts.count) contact(s)")
+				LogInfo("ContactStore returning \(contacts.count) contact(s)")
 				continuation.resume(returning: contacts)
 			} catch {
 				continuation.resume(throwing: error)

--- a/Libraries/CustomContactsHelpers/Sources/Internal/Logging.swift
+++ b/Libraries/CustomContactsHelpers/Sources/Internal/Logging.swift
@@ -10,11 +10,12 @@
 
 import OSLog
 
+/// Helper method that logs the thread being executed; uses `String(cString: __dispatch_queue_get_label(nil))`
 public func LogCurrentThread(_ message: @escaping @autoclosure () -> String) {
 	Logger().trace("🧵 \(message()): \(String(cString: __dispatch_queue_get_label(nil)))")
 }
 
-/// This method is functionally equivilent to the debug(_:) method.
+/// This method is functionally equivalent to the debug(_:) method.
 public func LogTrace(_ message: @escaping @autoclosure () -> String, file: String = #file, function: String = #function, line: UInt = #line) {
 #if !LOGS_DISABLED
 	Logger().trace(


### PR DESCRIPTION
- Begins updated Group creation flow with dedicated ViewModel
- Converts `ContactsRepository` to `protocol`; `ContactsRepositoryLive` to `actor`
- `ContactsProvider` changes put on hold until `ContactGroups is sorted out in next PR